### PR TITLE
 - default `process.env.NODE_ENV` to `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+## [0.2.8][] - 2018-02-09
+
+ - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack  
+
 ## [0.2.7][] - 2017-12-14
 
 ### Changed 
@@ -66,7 +70,8 @@ QA passed
 
 
 
-[Unreleased]: https://github.com/DeskproApps/trello/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/DeskproApps/trello/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/DeskproApps/trello/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/DeskproApps/trello/compare/v0.2.7-beta.3...v0.2.7
 [0.2.7-beta.3]: https://github.com/DeskproApps/trello/compare/v0.2.7-beta.2...v0.2.7-beta.3
 [0.2.7-beta.2]: https://github.com/DeskproApps/trello/compare/v0.2.7-beta.1...v0.2.7-beta.2

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "deskpro-app-trello",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deskpro-app-trello",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "This application adds a sidebar that lets you link tickets to trello cards",
   "main": "lib/main/javascript/index.js",
   "scripts": {

--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,6 +5,7 @@ module.exports = function (env) {
 
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : path.resolve(__dirname, '../../');
   const DEBUG = env && env.NODE_ENV === 'development';
+  const ENVIRONMENT =  env && env.NODE_ENV ? env.NODE_ENV : 'production';
 
   const buildManifest = new dpat.BuildManifest(
     PROJECT_ROOT_PATH,
@@ -67,7 +68,8 @@ module.exports = function (env) {
 
       new dpat.Webpack.DefinePlugin({
         DEBUG: DEBUG,
-        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent())
+        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent()),
+        'process.env.NODE_ENV': JSON.stringify(ENVIRONMENT)
       }),
 
       // for stable builds, in production we replace the default module index with the module's content hashe


### PR DESCRIPTION
 - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack