### PR TITLE
[Bug] Description Field In Edit Page Not Expanding (SC-180999)

### DIFF
--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -8,7 +8,8 @@ type Props = TextAreaWithDisplayProps & {
     minWidth?: number | string | "auto",
 };
 
-const TextArea = styled(TextAreaWithDisplay)<Props>`
+const TextArea = styled(TextAreaWithDisplay) <Props>`
+    height: auto;
     min-height: ${({ minWidth = 100 }) => typeof minWidth === "number" ? `${minWidth}px` : minWidth};
     font-size: 11px;
     font-family: ${({ theme }) => theme.fonts.primary};

--- a/src/pages/EditCardPage/EditCardPage.tsx
+++ b/src/pages/EditCardPage/EditCardPage.tsx
@@ -1,5 +1,5 @@
-import { Avatar, Button as ButtonUI, DivAsInputWithDisplay, Dropdown, DropdownTargetProps, DropdownValueType, InputWithDisplay, P5, Pill, Stack, TextArea, TSpan } from "@deskpro/deskpro-ui";
-import { Button, Container, EmptyInlineBlock, Label, SingleSelect, TextBlockWithLabel } from "../../components/common";
+import { Avatar, Button as ButtonUI, DivAsInputWithDisplay, Dropdown, DropdownTargetProps, DropdownValueType, InputWithDisplay, P5, Pill, Stack, TSpan } from "@deskpro/deskpro-ui";
+import { Button, Container, EmptyInlineBlock, Label, SingleSelect, TextArea, TextBlockWithLabel } from "../../components/common";
 import { CardType, Member } from "../../services/trello/types";
 import { DateInput, LoadingSpinner, useDeskproAppClient, useDeskproAppTheme, useDeskproElements, useDeskproLatestAppContext, useInitialisedDeskproAppClient } from "@deskpro/app-sdk";
 import { faUser, faPlus, faCheck, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/EditCardPage/EditCardPage.tsx
+++ b/src/pages/EditCardPage/EditCardPage.tsx
@@ -209,7 +209,7 @@ export function EditCardPage(): JSX.Element {
   if (isLoading) {
     return <LoadingSpinner />
   }
-  
+
   // Render edit form
   return (
     <Container>
@@ -247,6 +247,7 @@ export function EditCardPage(): JSX.Element {
 
         <Label htmlFor="description" label="Description">
           <TextArea
+            minWidth="auto"
             placeholder="Enter description"
             {...getFieldProps("description")}
           />

--- a/src/pages/EditCardPage/getCardDefaultData.ts
+++ b/src/pages/EditCardPage/getCardDefaultData.ts
@@ -9,7 +9,6 @@ interface CardDefaultData {
     labels: Labels
 }
 export default async function getCardDefaultData(client: IDeskproClient, cardId: string): Promise<CardDefaultData> {
-
     // Get the authenticated user
     const member = await getCurrentMemberService(client)
 


### PR DESCRIPTION
## Description 
The actual issue seems to have been fixed in #59. This PR updates the `TextArea` component being used when editing a card.

## Evidence


https://github.com/user-attachments/assets/e706fe94-6025-48d4-8f47-12aa5011b24d

